### PR TITLE
fix: correct tags for Simple Compiler and TBG Battle System

### DIFF
--- a/src/content/projects/simple-compiler/en.md
+++ b/src/content/projects/simple-compiler/en.md
@@ -4,10 +4,11 @@ category: "Embedded Systems"
 description: "Developed a simple compiler (still has 15,000 lines) that translates C language files into Intermediate Representation (IR) and MIPS32 assembly. The compiler supports essential features such as I/O operations, control flow and function calls. It includes comprehensive lexical, syntax, and semantic analysis, along with informative error messages."
 image: ./cover.png
 techStack:
-  - C++
-  - Arduino
-  - MQTT
-  - PlatformIO
+  - C
+  - Compiler Design
+  - IR
+  - MIPS32
+  - Parsing
 startDate: "2023-01-15"
 endDate: "2023-02-15"
 repoUrl: "https://github.com/IT-Bill/CS301-TBG-Battle-System"

--- a/src/content/projects/simple-compiler/zh.md
+++ b/src/content/projects/simple-compiler/zh.md
@@ -4,10 +4,11 @@ category: "Embedded Systems"
 description: "开发了一个简易编译器（代码量达 15,000 行），将 C 语言文件编译为中间表示（IR）和 MIPS32 汇编代码。编译器支持 I/O 操作、控制流和函数调用等核心功能，包含完整的词法、语法和语义分析及友好的错误提示。"
 image: ./cover.png
 techStack:
-  - C++
-  - Arduino
-  - MQTT
-  - PlatformIO
+  - C
+  - 编译原理
+  - IR
+  - MIPS32
+  - 语法分析
 startDate: "2023-01-15"
 endDate: "2023-02-15"
 repoUrl: "https://github.com/IT-Bill/CS301-TBG-Battle-System"

--- a/src/content/projects/tbg-battle-system/en.md
+++ b/src/content/projects/tbg-battle-system/en.md
@@ -5,9 +5,10 @@ description: "The system lets players choose actions for their customizable char
 image: ./cover.png
 techStack:
   - C++
-  - Arduino
-  - MQTT
-  - PlatformIO
+  - miniSTM32
+  - Embedded Systems
+  - Multiplayer
+  - Real-time Communication
 startDate: "2023-01-15"
 endDate: "2023-02-15"
 repoUrl: "https://github.com/IT-Bill/CS301-TBG-Battle-System"

--- a/src/content/projects/tbg-battle-system/zh.md
+++ b/src/content/projects/tbg-battle-system/zh.md
@@ -5,9 +5,10 @@ description: "该系统允许玩家为自定义角色选择动作、追踪生命
 image: ./cover.png
 techStack:
   - C++
-  - Arduino
-  - MQTT
-  - PlatformIO
+  - miniSTM32
+  - 嵌入式系统
+  - 多人对战
+  - 实时通信
 startDate: "2023-01-15"
 endDate: "2023-02-15"
 repoUrl: "https://github.com/IT-Bill/CS301-TBG-Battle-System"


### PR DESCRIPTION
## Summary
- fix incorrect tech tags for Simple Compiler project
- fix incorrect tech tags for TBG Battle System in MiniSTM32 project
- update both English and Chinese content files

## Updated files
- src/content/projects/simple-compiler/en.md
- src/content/projects/simple-compiler/zh.md
- src/content/projects/tbg-battle-system/en.md
- src/content/projects/tbg-battle-system/zh.md
