### PR TITLE
fix: prevent mobile overflow from Creative Expression tooltip

### DIFF
--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -327,7 +327,7 @@ const PROJECTS = projectEntries
             {t('home.creativeExpression')}
             <span class="relative inline-flex items-center justify-center w-5 h-5 rounded-full border border-border text-xs text-muted-foreground cursor-help group" tabindex="0" aria-label={t('home.creativeExpression.tooltip')}>
               ?
-              <span class="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-72 -translate-x-1/2 rounded-lg border border-border/60 bg-card px-3 py-2 text-xs font-normal text-muted-foreground text-left opacity-0 shadow-lg transition-opacity duration-200 group-hover:opacity-100 group-focus:opacity-100">
+              <span class="pointer-events-none absolute right-0 top-full z-10 mt-2 w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-border/60 bg-card px-3 py-2 text-xs font-normal text-muted-foreground text-left opacity-0 shadow-lg transition-opacity duration-200 group-hover:opacity-100 group-focus:opacity-100 md:left-1/2 md:right-auto md:-translate-x-1/2">
                 {t('home.creativeExpression.tooltip')}
               </span>
             </span>


### PR DESCRIPTION
## Summary\n- fix tooltip positioning for the Creative Expression help icon on mobile\n- avoid horizontal overflow that caused extra blank area on the right\n- keep centered tooltip behavior on desktop\n\n## Change\n- mobile: anchor tooltip to the right edge with viewport-based max width\n- desktop: keep existing centered alignment