### PR TITLE
feat: add blog link to top bar

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -10,12 +10,14 @@ interface Props {
 const { lang = 'en' } = Astro.props;
 const t = useTranslations(lang);
 const altLang = getAlternateLang(lang);
+const blogUrl = 'https://it-bill.github.io/blog/';
 
 const navLinks = [
   { href: getLocalePath('/', lang), label: t('nav.home') },
   { href: getLocalePath('/experiences', lang), label: t('nav.experiences') },
   { href: getLocalePath('/publications', lang), label: t('nav.publications') },
   { href: getLocalePath('/projects', lang), label: t('nav.projects') },
+  { href: blogUrl, label: t('nav.blog') },
 ];
 const currentPath = Astro.url.pathname;
 const switchUrl = getSwitchLangUrl(Astro.url);

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -17,7 +17,7 @@ const navLinks = [
   { href: getLocalePath('/experiences', lang), label: t('nav.experiences') },
   { href: getLocalePath('/publications', lang), label: t('nav.publications') },
   { href: getLocalePath('/projects', lang), label: t('nav.projects') },
-  { href: blogUrl, label: t('nav.blog') },
+  { href: blogUrl, label: t('nav.blog'), external: true },
 ];
 const currentPath = Astro.url.pathname;
 const switchUrl = getSwitchLangUrl(Astro.url);
@@ -41,9 +41,11 @@ function isActive(href: string): boolean {
 
       <!-- Desktop Navigation -->
       <nav class="hidden md:flex items-center gap-8">
-        {navLinks.map(({ href, label }) => (
+        {navLinks.map(({ href, label, external }) => (
           <a
             href={href}
+            target={external ? '_blank' : undefined}
+            rel={external ? 'noopener noreferrer' : undefined}
             class:list={[
               'text-base font-medium transition-colors hover:text-primary',
               isActive(href)
@@ -108,9 +110,11 @@ function isActive(href: string): boolean {
 
   <!-- Mobile Navigation -->
   <div id="mobile-menu" class="md:hidden border-t border-border/60 bg-background px-4 py-4 space-y-4 hidden">
-    {navLinks.map(({ href, label }) => (
+    {navLinks.map(({ href, label, external }) => (
       <a
         href={href}
+        target={external ? '_blank' : undefined}
+        rel={external ? 'noopener noreferrer' : undefined}
         class:list={[
           'block text-base font-medium transition-colors',
           isActive(href)

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -18,6 +18,7 @@ export const ui = {
     'nav.experiences': 'Experiences',
     'nav.publications': 'Publications',
     'nav.projects': 'Projects',
+    'nav.blog': 'Blog',
     'nav.contact': 'Contact',
 
     // Home page
@@ -104,6 +105,7 @@ export const ui = {
     'nav.experiences': '经历',
     'nav.publications': '论文',
     'nav.projects': '项目',
+    'nav.blog': '博客',
     'nav.contact': '联系',
 
     // Home page


### PR DESCRIPTION
## Summary
- add a Blog link to the top navigation bar
- localize the label in both English and Chinese
- keep the link available in both desktop and mobile navigation

## Testing
- pnpm build